### PR TITLE
Fix blog code blocks and syntax highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,13 @@
         "@astrojs/sitemap": "^3.1.6",
         "@astrojs/tailwind": "^5.1.1",
         "astro": "^4.15.11",
+        "hastscript": "^9.0.1",
+        "remark-admonitions": "^1.2.1",
+        "remark-directive": "^4.0.0",
         "simple-icons": "^15.20.0",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.6.2"
+        "typescript": "^5.6.2",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.15",
@@ -3979,6 +3983,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -4434,6 +4461,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -4797,6 +4845,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -6449,6 +6516,284 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/remark-admonitions/-/remark-admonitions-1.2.1.tgz",
+      "integrity": "sha512-Ji6p68VDvD+H1oS95Fdx9Ar5WA2wcDA4kwrrhVU7fGctC6+d3uiMICu7w7/2Xld+lnU7/gi+432+rRbup5S8ow==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-parse": "^6.0.2",
+        "unified": "^8.4.2",
+        "unist-util-visit": "^2.0.1"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/remark-admonitions/node_modules/bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/ccount": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/hast-util-from-parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "license": "MIT",
+      "dependencies": {
+        "ccount": "^1.0.3",
+        "hastscript": "^5.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.1.2",
+        "xtend": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT"
+    },
+    "node_modules/remark-admonitions/node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/rehype-parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+      "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "license": "MIT",
+      "dependencies": {
+        "hast-util-from-parse5": "^5.0.0",
+        "parse5": "^5.0.0",
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/unified": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-admonitions/node_modules/web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -8155,6 +8500,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,13 @@
     "@astrojs/sitemap": "^3.1.6",
     "@astrojs/tailwind": "^5.1.1",
     "astro": "^4.15.11",
+    "hastscript": "^9.0.1",
+    "remark-admonitions": "^1.2.1",
+    "remark-directive": "^4.0.0",
     "simple-icons": "^15.20.0",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",

--- a/src/components/FlagIcon.astro
+++ b/src/components/FlagIcon.astro
@@ -1,0 +1,35 @@
+---
+interface Props {
+  country: 'us' | 'vn';
+  class?: string;
+}
+
+const { country, class: className = 'w-4 h-4' } = Astro.props;
+---
+
+{country === 'us' && (
+  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="2" fill="#B22234"/>
+    <path d="M0 3.69231H24M0 6.46154H24M0 9.23077H24M0 12H24M0 14.7692H24M0 17.5385H24M0 20.3077H24" stroke="white" stroke-width="1.8"/>
+    <rect width="10" height="12.9231" rx="1" fill="#3C3B6E"/>
+    <circle cx="2.5" cy="2.5" r="0.5" fill="white"/>
+    <circle cx="5" cy="2.5" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="2.5" r="0.5" fill="white"/>
+    <circle cx="2.5" cy="5" r="0.5" fill="white"/>
+    <circle cx="5" cy="5" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="5" r="0.5" fill="white"/>
+    <circle cx="2.5" cy="7.5" r="0.5" fill="white"/>
+    <circle cx="5" cy="7.5" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="7.5" r="0.5" fill="white"/>
+    <circle cx="2.5" cy="10" r="0.5" fill="white"/>
+    <circle cx="5" cy="10" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="10" r="0.5" fill="white"/>
+  </svg>
+)}
+
+{country === 'vn' && (
+  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="2" fill="#DA251D"/>
+    <path d="M12 6L13.545 10.764H18.708L14.582 13.736L16.127 18.5L12 15.528L7.873 18.5L9.418 13.736L5.292 10.764H10.455L12 6Z" fill="#FFFF00"/>
+  </svg>
+)}

--- a/src/components/FlagIcon.astro
+++ b/src/components/FlagIcon.astro
@@ -4,47 +4,39 @@ interface Props {
   class?: string;
 }
 
-const { country, class: className = 'w-6 h-4' } = Astro.props;
+const { country, class: className = 'w-5 h-5' } = Astro.props;
 ---
 
 {country === 'us' && (
-  <svg class={className} viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="30" height="20" rx="1" fill="#B22234"/>
-    <path d="M0 2.46154H30M0 4.30769H30M0 6.15385H30M0 8H30M0 9.84615H30M0 11.6923H30M0 13.5385H30" stroke="white" stroke-width="1.2"/>
-    <rect width="12" height="10.7692" rx="0.5" fill="#3C3B6E"/>
-    <circle cx="2" cy="2" r="0.4" fill="white"/>
-    <circle cx="4" cy="2" r="0.4" fill="white"/>
-    <circle cx="6" cy="2" r="0.4" fill="white"/>
-    <circle cx="8" cy="2" r="0.4" fill="white"/>
-    <circle cx="10" cy="2" r="0.4" fill="white"/>
-    <circle cx="2" cy="4" r="0.4" fill="white"/>
-    <circle cx="4" cy="4" r="0.4" fill="white"/>
-    <circle cx="6" cy="4" r="0.4" fill="white"/>
-    <circle cx="8" cy="4" r="0.4" fill="white"/>
-    <circle cx="10" cy="4" r="0.4" fill="white"/>
-    <circle cx="2" cy="6" r="0.4" fill="white"/>
-    <circle cx="4" cy="6" r="0.4" fill="white"/>
-    <circle cx="6" cy="6" r="0.4" fill="white"/>
-    <circle cx="8" cy="6" r="0.4" fill="white"/>
-    <circle cx="10" cy="6" r="0.4" fill="white"/>
-    <circle cx="2" cy="8" r="0.4" fill="white"/>
-    <circle cx="4" cy="8" r="0.4" fill="white"/>
-    <circle cx="6" cy="8" r="0.4" fill="white"/>
-    <circle cx="8" cy="8" r="0.4" fill="white"/>
-    <circle cx="10" cy="8" r="0.4" fill="white"/>
+  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="2" fill="#B22234"/>
+    <path d="M0 3.69231H24M0 6.46154H24M0 9.23077H24M0 12H24M0 14.7692H24M0 17.5385H24M0 20.3077H24" stroke="white" stroke-width="1.8"/>
+    <rect width="10" height="12.9231" rx="1" fill="#3C3B6E"/>
+    <circle cx="2.5" cy="2.5" r="0.5" fill="white"/>
+    <circle cx="5" cy="2.5" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="2.5" r="0.5" fill="white"/>
+    <circle cx="2.5" cy="5" r="0.5" fill="white"/>
+    <circle cx="5" cy="5" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="5" r="0.5" fill="white"/>
+    <circle cx="2.5" cy="7.5" r="0.5" fill="white"/>
+    <circle cx="5" cy="7.5" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="7.5" r="0.5" fill="white"/>
+    <circle cx="2.5" cy="10" r="0.5" fill="white"/>
+    <circle cx="5" cy="10" r="0.5" fill="white"/>
+    <circle cx="7.5" cy="10" r="0.5" fill="white"/>
   </svg>
 )}
 
 {country === 'vn' && (
-  <svg class={className} viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="30" height="20" rx="1" fill="#DA251D"/>
-    <path d="M15 5L17.045 11.527H24.27L18.612 15.446L20.657 22L15 18.081L9.343 22L11.388 15.446L5.73 11.527H12.955L15 5Z" fill="#FFFF00"/>
+  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="2" fill="#DA251D"/>
+    <path d="M12 6L13.545 10.764H18.708L14.582 13.736L16.127 18.5L12 15.528L7.873 18.5L9.418 13.736L5.292 10.764H10.455L12 6Z" fill="#FFFF00"/>
   </svg>
 )}
 
 {country === 'jp' && (
-  <svg class={className} viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="30" height="20" rx="1" fill="white"/>
-    <circle cx="15" cy="10" r="6" fill="#BC002D"/>
+  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="2" fill="white"/>
+    <circle cx="12" cy="12" r="6" fill="#BC002D"/>
   </svg>
 )}

--- a/src/components/FlagIcon.astro
+++ b/src/components/FlagIcon.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  country: 'us' | 'vn';
+  country: 'us' | 'vn' | 'jp';
   class?: string;
 }
 
@@ -31,5 +31,12 @@ const { country, class: className = 'w-4 h-4' } = Astro.props;
   <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <rect width="24" height="24" rx="2" fill="#DA251D"/>
     <path d="M12 6L13.545 10.764H18.708L14.582 13.736L16.127 18.5L12 15.528L7.873 18.5L9.418 13.736L5.292 10.764H10.455L12 6Z" fill="#FFFF00"/>
+  </svg>
+)}
+
+{country === 'jp' && (
+  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="24" height="24" rx="2" fill="white"/>
+    <circle cx="12" cy="12" r="6" fill="#BC002D"/>
   </svg>
 )}

--- a/src/components/FlagIcon.astro
+++ b/src/components/FlagIcon.astro
@@ -4,39 +4,47 @@ interface Props {
   class?: string;
 }
 
-const { country, class: className = 'w-4 h-4' } = Astro.props;
+const { country, class: className = 'w-6 h-4' } = Astro.props;
 ---
 
 {country === 'us' && (
-  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="24" height="24" rx="2" fill="#B22234"/>
-    <path d="M0 3.69231H24M0 6.46154H24M0 9.23077H24M0 12H24M0 14.7692H24M0 17.5385H24M0 20.3077H24" stroke="white" stroke-width="1.8"/>
-    <rect width="10" height="12.9231" rx="1" fill="#3C3B6E"/>
-    <circle cx="2.5" cy="2.5" r="0.5" fill="white"/>
-    <circle cx="5" cy="2.5" r="0.5" fill="white"/>
-    <circle cx="7.5" cy="2.5" r="0.5" fill="white"/>
-    <circle cx="2.5" cy="5" r="0.5" fill="white"/>
-    <circle cx="5" cy="5" r="0.5" fill="white"/>
-    <circle cx="7.5" cy="5" r="0.5" fill="white"/>
-    <circle cx="2.5" cy="7.5" r="0.5" fill="white"/>
-    <circle cx="5" cy="7.5" r="0.5" fill="white"/>
-    <circle cx="7.5" cy="7.5" r="0.5" fill="white"/>
-    <circle cx="2.5" cy="10" r="0.5" fill="white"/>
-    <circle cx="5" cy="10" r="0.5" fill="white"/>
-    <circle cx="7.5" cy="10" r="0.5" fill="white"/>
+  <svg class={className} viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="30" height="20" rx="1" fill="#B22234"/>
+    <path d="M0 2.46154H30M0 4.30769H30M0 6.15385H30M0 8H30M0 9.84615H30M0 11.6923H30M0 13.5385H30" stroke="white" stroke-width="1.2"/>
+    <rect width="12" height="10.7692" rx="0.5" fill="#3C3B6E"/>
+    <circle cx="2" cy="2" r="0.4" fill="white"/>
+    <circle cx="4" cy="2" r="0.4" fill="white"/>
+    <circle cx="6" cy="2" r="0.4" fill="white"/>
+    <circle cx="8" cy="2" r="0.4" fill="white"/>
+    <circle cx="10" cy="2" r="0.4" fill="white"/>
+    <circle cx="2" cy="4" r="0.4" fill="white"/>
+    <circle cx="4" cy="4" r="0.4" fill="white"/>
+    <circle cx="6" cy="4" r="0.4" fill="white"/>
+    <circle cx="8" cy="4" r="0.4" fill="white"/>
+    <circle cx="10" cy="4" r="0.4" fill="white"/>
+    <circle cx="2" cy="6" r="0.4" fill="white"/>
+    <circle cx="4" cy="6" r="0.4" fill="white"/>
+    <circle cx="6" cy="6" r="0.4" fill="white"/>
+    <circle cx="8" cy="6" r="0.4" fill="white"/>
+    <circle cx="10" cy="6" r="0.4" fill="white"/>
+    <circle cx="2" cy="8" r="0.4" fill="white"/>
+    <circle cx="4" cy="8" r="0.4" fill="white"/>
+    <circle cx="6" cy="8" r="0.4" fill="white"/>
+    <circle cx="8" cy="8" r="0.4" fill="white"/>
+    <circle cx="10" cy="8" r="0.4" fill="white"/>
   </svg>
 )}
 
 {country === 'vn' && (
-  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="24" height="24" rx="2" fill="#DA251D"/>
-    <path d="M12 6L13.545 10.764H18.708L14.582 13.736L16.127 18.5L12 15.528L7.873 18.5L9.418 13.736L5.292 10.764H10.455L12 6Z" fill="#FFFF00"/>
+  <svg class={className} viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="30" height="20" rx="1" fill="#DA251D"/>
+    <path d="M15 5L17.045 11.527H24.27L18.612 15.446L20.657 22L15 18.081L9.343 22L11.388 15.446L5.73 11.527H12.955L15 5Z" fill="#FFFF00"/>
   </svg>
 )}
 
 {country === 'jp' && (
-  <svg class={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect width="24" height="24" rx="2" fill="white"/>
-    <circle cx="12" cy="12" r="6" fill="#BC002D"/>
+  <svg class={className} viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect width="30" height="20" rx="1" fill="white"/>
+    <circle cx="15" cy="10" r="6" fill="#BC002D"/>
   </svg>
 )}

--- a/src/components/LanguageBadge.astro
+++ b/src/components/LanguageBadge.astro
@@ -1,15 +1,17 @@
 ---
-import { getLanguageInfo } from '@utils/helpers';
+import FlagIcon from './FlagIcon.astro';
 
 interface Props {
   language: 'en' | 'vi';
 }
 
 const { language } = Astro.props;
-const info = getLanguageInfo(language);
+const country = language === 'en' ? 'us' : 'vn';
+const label = language === 'en' ? 'English' : 'Tiếng Việt';
+const badgeClass = language === 'en' ? 'lang-badge-en' : 'lang-badge-vi';
 ---
 
-<span class={`lang-badge ${info.class}`}>
-  <span>{info.flag}</span>
-  <span>{info.label === 'English' ? 'EN' : 'VI'}</span>
+<span class={`lang-badge ${badgeClass}`}>
+  <FlagIcon country={country} class="w-4 h-4" />
+  <span>{label}</span>
 </span>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,6 +1,5 @@
 ---
 import { languages, defaultLang, getLangFromUrl, getLocalizedPath } from '@i18n/utils';
-import FlagIcon from './FlagIcon.astro';
 
 const currentLang = getLangFromUrl(Astro.url);
 const currentPath = Astro.url.pathname.replace(new RegExp(`^/${currentLang}`), '') || '/';
@@ -8,17 +7,18 @@ const currentPath = Astro.url.pathname.replace(new RegExp(`^/${currentLang}`), '
 // Generate alternate language URL
 const alternateLang = currentLang === 'en' ? 'vi' : 'en';
 const alternateUrl = getLocalizedPath(currentPath, alternateLang);
-const alternateCountry = alternateLang === 'en' ? 'us' : 'vn';
 ---
 
 <div class="language-switcher">
   <a
     href={alternateUrl}
-    class="flex items-center justify-center p-2 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+    class="flex items-center justify-center px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
     aria-label={`Switch to ${languages[alternateLang]}`}
     title={`Switch to ${languages[alternateLang]}`}
   >
-    <FlagIcon country={alternateCountry} class="w-6 h-6" />
+    <span class="text-sm font-medium">
+      {alternateLang.toUpperCase()}
+    </span>
   </a>
 </div>
 

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -14,14 +14,11 @@ const alternateCountry = alternateLang === 'en' ? 'us' : 'vn';
 <div class="language-switcher">
   <a
     href={alternateUrl}
-    class="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+    class="flex items-center justify-center p-2 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
     aria-label={`Switch to ${languages[alternateLang]}`}
     title={`Switch to ${languages[alternateLang]}`}
   >
-    <FlagIcon country={alternateCountry} class="w-5 h-5" />
-    <span class="text-sm font-medium">
-      {languages[alternateLang]}
-    </span>
+    <FlagIcon country={alternateCountry} class="w-6 h-6" />
   </a>
 </div>
 

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -18,7 +18,7 @@ const alternateCountry = alternateLang === 'en' ? 'us' : 'vn';
     aria-label={`Switch to ${languages[alternateLang]}`}
     title={`Switch to ${languages[alternateLang]}`}
   >
-    <FlagIcon country={alternateCountry} class="w-6 h-6" />
+    <FlagIcon country={alternateCountry} class="w-9 h-6" />
   </a>
 </div>
 

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,5 +1,6 @@
 ---
 import { languages, defaultLang, getLangFromUrl, getLocalizedPath } from '@i18n/utils';
+import FlagIcon from './FlagIcon.astro';
 
 const currentLang = getLangFromUrl(Astro.url);
 const currentPath = Astro.url.pathname.replace(new RegExp(`^/${currentLang}`), '') || '/';
@@ -7,6 +8,7 @@ const currentPath = Astro.url.pathname.replace(new RegExp(`^/${currentLang}`), '
 // Generate alternate language URL
 const alternateLang = currentLang === 'en' ? 'vi' : 'en';
 const alternateUrl = getLocalizedPath(currentPath, alternateLang);
+const alternateCountry = alternateLang === 'en' ? 'us' : 'vn';
 ---
 
 <div class="language-switcher">
@@ -16,11 +18,9 @@ const alternateUrl = getLocalizedPath(currentPath, alternateLang);
     aria-label={`Switch to ${languages[alternateLang]}`}
     title={`Switch to ${languages[alternateLang]}`}
   >
-    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"></path>
-    </svg>
+    <FlagIcon country={alternateCountry} class="w-5 h-5" />
     <span class="text-sm font-medium">
-      {currentLang === 'en' ? 'VI' : 'EN'}
+      {languages[alternateLang]}
     </span>
   </a>
 </div>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -18,7 +18,7 @@ const alternateCountry = alternateLang === 'en' ? 'us' : 'vn';
     aria-label={`Switch to ${languages[alternateLang]}`}
     title={`Switch to ${languages[alternateLang]}`}
   >
-    <FlagIcon country={alternateCountry} class="w-9 h-6" />
+    <FlagIcon country={alternateCountry} class="w-6 h-6" />
   </a>
 </div>
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -27,7 +27,7 @@ export default {
       title: 'About Me',
       subtitle: 'AI Engineer with Master\'s degree from JAIST, specializing in production ML systems',
       greeting: 'Hello there!',
-      bio1: 'I\'m Hieu Nguyen, an AI Engineer from Vietnam 🇻🇳 with a passion for transforming research into production-ready systems.',
+      bio1: 'I\'m Hieu Nguyen, an AI Engineer from Vietnam with a passion for transforming research into production-ready systems.',
       bio2: 'My expertise lies in Natural Language Processing, RAG systems, and Large Language Models. I specialize in building scalable AI solutions that solve real-world problems.',
       bio3: 'I hold a {degree} from {school} in Japan, where I deepened my knowledge in information retrieval and machine learning.',
       bio4: 'When I\'m not coding, you\'ll find me exploring self-hosted solutions, contributing to open source, or writing about AI/ML on my blog.',
@@ -87,7 +87,7 @@ export default {
     quickInfo: {
       title: 'Quick Info',
       location: 'Location',
-      locationValue: 'Hanoi, Vietnam 🇻🇳',
+      locationValue: 'Hanoi, Vietnam',
       role: 'Role',
       roleValue: 'AI Engineer',
       education: 'Education',
@@ -124,8 +124,8 @@ export default {
     readArticle: 'Read Article',
     emptyState: 'No posts found',
     clearFilters: 'Clear filters',
-    english: '🇺🇸 English',
-    vietnamese: '🇻🇳 Vietnamese',
+    english: 'English',
+    vietnamese: 'Vietnamese',
     filter: {
       all: 'All',
       aiml: 'AI/ML',

--- a/src/i18n/vi.ts
+++ b/src/i18n/vi.ts
@@ -27,7 +27,7 @@ export default {
       title: 'Về Tôi',
       subtitle: 'Kỹ sư AI với bằng Thạc sĩ từ JAIST, chuyên về hệ thống ML production',
       greeting: 'Xin chào!',
-      bio1: 'Tôi là Hiếu Nguyễn, một Kỹ sư AI từ Việt Nam 🇻🇳 với đam mê chuyển đổi nghiên cứu thành các hệ thống production.',
+      bio1: 'Tôi là Hiếu Nguyễn, một Kỹ sư AI từ Việt Nam với đam mê chuyển đổi nghiên cứu thành các hệ thống production.',
       bio2: 'Chuyên môn của tôi nằm ở Xử lý Ngôn ngữ Tự nhiên, hệ thống RAG và Mô hình Ngôn ngữ Lớn. Tôi chuyên xây dựng các giải pháp AI có khả năng mở rộng để giải quyết các vấn đề thực tế.',
       bio3: 'Tôi có bằng {degree} từ {school} ở Nhật Bản, nơi tôi đã nâng cao kiến thức về truy xuất thông tin và học máy.',
       bio4: 'Khi không code, bạn sẽ thấy tôi khám phá các giải pháp self-hosted, đóng góp cho open source, hoặc viết về AI/ML trên blog.',
@@ -87,7 +87,7 @@ export default {
     quickInfo: {
       title: 'Thông Tin Nhanh',
       location: 'Vị Trí',
-      locationValue: 'Hà Nội, Việt Nam 🇻🇳',
+      locationValue: 'Hà Nội, Việt Nam',
       role: 'Vai Trò',
       roleValue: 'Kỹ Sư AI',
       education: 'Học Vấn',
@@ -124,8 +124,8 @@ export default {
     readArticle: 'Đọc Bài Viết',
     emptyState: 'Không tìm thấy bài viết',
     clearFilters: 'Xóa bộ lọc',
-    english: '🇺🇸 English',
-    vietnamese: '🇻🇳 Tiếng Việt',
+    english: 'English',
+    vietnamese: 'Tiếng Việt',
     filter: {
       all: 'Tất Cả',
       aiml: 'AI/ML',

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -3,6 +3,7 @@ import BaseLayout from './BaseLayout.astro';
 import TableOfContents from '@components/TableOfContents.astro';
 import Giscus from '@components/Giscus.astro';
 import LanguageBadge from '@components/LanguageBadge.astro';
+import SocialIcon from '@components/SocialIcon.astro';
 import { formatDate, getCategoryColor } from '@utils/helpers';
 import type { CollectionEntry } from 'astro:content';
 
@@ -102,23 +103,31 @@ const { title, description, date, updated, author, category, tags, language } = 
               href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(Astro.url.href)}`}
               target="_blank"
               rel="noopener noreferrer"
-              class="btn-secondary text-sm"
+              class="btn-secondary text-sm flex items-center gap-2"
+              aria-label="Share on Twitter"
             >
-              🐦 Twitter
+              <SocialIcon name="twitter" class="w-4 h-4" />
+              <span>Twitter</span>
             </a>
             <a
               href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(Astro.url.href)}`}
               target="_blank"
               rel="noopener noreferrer"
-              class="btn-secondary text-sm"
+              class="btn-secondary text-sm flex items-center gap-2"
+              aria-label="Share on LinkedIn"
             >
-              💼 LinkedIn
+              <SocialIcon name="linkedin" class="w-4 h-4" />
+              <span>LinkedIn</span>
             </a>
             <button
               id="copy-link"
-              class="btn-secondary text-sm"
+              class="btn-secondary text-sm flex items-center gap-2"
+              aria-label="Copy link to clipboard"
             >
-              🔗 Copy Link
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
+              </svg>
+              <span>Copy Link</span>
             </button>
           </div>
         </div>
@@ -155,13 +164,49 @@ const { title, description, date, updated, author, category, tags, language } = 
   document.getElementById('copy-link')?.addEventListener('click', async () => {
     await navigator.clipboard.writeText(window.location.href);
     const button = document.getElementById('copy-link');
-    const originalText = button?.textContent || '';
-    if (button) {
-      button.textContent = '✓ Copied!';
+    const span = button?.querySelector('span');
+    if (span) {
+      const originalText = span.textContent || '';
+      span.textContent = '✓ Copied!';
       setTimeout(() => {
-        button.textContent = originalText;
+        span.textContent = originalText;
       }, 2000);
     }
+  });
+
+  // Add copy buttons to code blocks
+  document.querySelectorAll('.prose pre').forEach((pre) => {
+    // Create copy button
+    const button = document.createElement('button');
+    button.className = 'copy-button';
+    button.textContent = 'Copy';
+    button.setAttribute('aria-label', 'Copy code to clipboard');
+
+    // Add click handler
+    button.addEventListener('click', async () => {
+      const code = pre.querySelector('code');
+      if (code) {
+        const text = code.textContent || '';
+        try {
+          await navigator.clipboard.writeText(text);
+          button.textContent = 'Copied!';
+          button.classList.add('copied');
+          setTimeout(() => {
+            button.textContent = 'Copy';
+            button.classList.remove('copied');
+          }, 2000);
+        } catch (err) {
+          console.error('Failed to copy code:', err);
+          button.textContent = 'Failed';
+          setTimeout(() => {
+            button.textContent = 'Copy';
+          }, 2000);
+        }
+      }
+    });
+
+    // Append button to pre element
+    pre.appendChild(button);
   });
 
   // Smooth scroll for anchor links

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogCard from '@components/BlogCard.astro';
+import FlagIcon from '@components/FlagIcon.astro';
 import { readingTime } from '@utils/helpers';
 import { getLangFromUrl, useTranslations } from '@i18n/utils';
 
@@ -87,7 +88,8 @@ const featuredPost = sortedPosts[0];
         </p>
         <div class="flex items-center gap-4 flex-wrap">
           <span class={`lang-badge ${featuredPost.data.language === 'vi' ? 'lang-badge-vi' : 'lang-badge-en'}`}>
-            {featuredPost.data.language === 'vi' ? '🇻🇳 VI' : '🇺🇸 EN'}
+            <FlagIcon country={featuredPost.data.language === 'vi' ? 'vn' : 'us'} class="w-4 h-4" />
+            <span>{featuredPost.data.language === 'vi' ? 'VI' : 'EN'}</span>
           </span>
           <span class="category-badge category-ai">{featuredPost.data.category}</span>
           <span class="text-sm text-[var(--color-text-muted)]">

--- a/src/pages/vi/blog/index.astro
+++ b/src/pages/vi/blog/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import BlogCard from '@components/BlogCard.astro';
+import FlagIcon from '@components/FlagIcon.astro';
 import { readingTime } from '@utils/helpers';
 import { getLangFromUrl, useTranslations } from '@i18n/utils';
 
@@ -87,7 +88,8 @@ const featuredPost = sortedPosts[0];
         </p>
         <div class="flex items-center gap-4 flex-wrap">
           <span class={`lang-badge ${featuredPost.data.language === 'vi' ? 'lang-badge-vi' : 'lang-badge-en'}`}>
-            {featuredPost.data.language === 'vi' ? '🇻🇳 VI' : '🇺🇸 EN'}
+            <FlagIcon country={featuredPost.data.language === 'vi' ? 'vn' : 'us'} class="w-4 h-4" />
+            <span>{featuredPost.data.language === 'vi' ? 'VI' : 'EN'}</span>
           </span>
           <span class="category-badge category-ai">{featuredPost.data.category}</span>
           <span class="text-sm text-[var(--color-text-muted)]">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -133,11 +133,34 @@
 }
 
 .prose pre {
-  @apply bg-slate-900 dark:bg-slate-950 rounded-lg p-4 overflow-x-auto my-6;
+  @apply bg-slate-100 dark:bg-slate-900 rounded-lg p-4 overflow-x-auto my-6 relative;
+  position: relative;
 }
 
 .prose pre code {
-  @apply bg-transparent text-slate-100 p-0;
+  @apply bg-transparent p-0;
+}
+
+/* Code block wrapper with copy button */
+.prose .code-block-wrapper {
+  @apply relative;
+}
+
+.prose pre:hover .copy-button {
+  @apply opacity-100;
+}
+
+.prose .copy-button {
+  @apply absolute top-2 right-2 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 dark:bg-slate-600 dark:hover:bg-slate-500 text-white text-xs rounded opacity-0 transition-all duration-200 cursor-pointer font-sans;
+  z-index: 10;
+}
+
+.prose .copy-button:hover {
+  @apply shadow-lg;
+}
+
+.prose .copy-button.copied {
+  @apply bg-green-600 hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-600;
 }
 
 .prose blockquote {
@@ -185,6 +208,56 @@
 
 .lang-badge-vi {
   @apply bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300;
+}
+
+/* Admonitions (:::tip:::, :::warning:::, etc.) */
+.prose .admonition {
+  @apply my-6 p-4 rounded-lg border-l-4;
+}
+
+.prose .admonition-tip {
+  @apply bg-blue-50 dark:bg-blue-950 border-blue-500 text-blue-900 dark:text-blue-100;
+}
+
+.prose .admonition-tip::before {
+  content: '💡 Tip';
+  @apply block font-bold mb-2 text-blue-700 dark:text-blue-300;
+}
+
+.prose .admonition-warning {
+  @apply bg-yellow-50 dark:bg-yellow-950 border-yellow-500 text-yellow-900 dark:text-yellow-100;
+}
+
+.prose .admonition-warning::before {
+  content: '⚠️ Warning';
+  @apply block font-bold mb-2 text-yellow-700 dark:text-yellow-300;
+}
+
+.prose .admonition-danger {
+  @apply bg-red-50 dark:bg-red-950 border-red-500 text-red-900 dark:text-red-100;
+}
+
+.prose .admonition-danger::before {
+  content: '🚨 Danger';
+  @apply block font-bold mb-2 text-red-700 dark:text-red-300;
+}
+
+.prose .admonition-note {
+  @apply bg-gray-50 dark:bg-gray-950 border-gray-500 text-gray-900 dark:text-gray-100;
+}
+
+.prose .admonition-note::before {
+  content: '📝 Note';
+  @apply block font-bold mb-2 text-gray-700 dark:text-gray-300;
+}
+
+.prose .admonition-info {
+  @apply bg-cyan-50 dark:bg-cyan-950 border-cyan-500 text-cyan-900 dark:text-cyan-100;
+}
+
+.prose .admonition-info::before {
+  content: 'ℹ️ Info';
+  @apply block font-bold mb-2 text-cyan-700 dark:text-cyan-300;
 }
 
 /* Category badges */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,7 +4,7 @@ export const SITE = {
   url: 'https://behitek.com',
   author: 'Hieu Nguyen',
   email: 'hello@behitek.com',
-  tagline: 'AI Engineer • Vietnam 🇻🇳',
+  tagline: 'AI Engineer • Vietnam',
   bio: 'I love bringing AI into production to solve real problems, with a focus on natural language processing, retrieval augmented generation (RAG), LLMs, and information retrieval.',
 };
 
@@ -40,7 +40,7 @@ export const NAV_LINKS = [
 export const EDUCATION = {
   degree: "Master's in Information Science",
   school: 'Japan Advanced Institute of Science and Technology (JAIST)',
-  country: '🇯🇵 Japan',
+  country: 'Japan',
 };
 
 export const TECH_STACK = {


### PR DESCRIPTION
- Add syntax-highlighted code blocks with copy button functionality
- Improve code block color contrast with better Shiki themes (github-light/github-dark-dimmed)
- Add support for Docusaurus-style admonitions (:::tip:::, :::warning:::, etc.)
- Replace emoji icons with professional SVG icons from simple-icons for social share buttons
- Add hover effects and visual feedback for copy buttons
- Improve accessibility with proper aria-labels

Technical changes:
- Install remark-directive and remark-admonitions for MDX admonition support
- Add custom remark plugin to handle admonition rendering
- Add CSS styles for 5 admonition types (tip, warning, danger, note, info)
- Implement JavaScript code block copy functionality
- Update BlogPostLayout to use SocialIcon component for Twitter/LinkedIn